### PR TITLE
small changes to keep the product name consistent

### DIFF
--- a/src/de/index.md.trans
+++ b/src/de/index.md.trans
@@ -50,7 +50,7 @@
     freely used and audited.
 3956494063c9ddc7:
   de: '## Was Kiebitz ausmacht'
-  en: '## What makes lapwing'
+  en: '## The characteristics of Kiebitz'
 3d111a9375d5e0d4:
   de: '# Willkommen!'
   en: '# Welcome!'

--- a/src/en/index.md
+++ b/src/en/index.md
@@ -2,7 +2,7 @@
 
 Kiebitz is an [open source](https://github.com/kiebitz-oss), free and freely usable software solution for privacy-friendly appointment scheduling. This page documents the protocol and applications that make up Kiebitz.
 
-## What makes lapwing
+## The characteristics of Kiebitz[^1]
 
 Kiebitz systematically minimizes privacy & security risks for users of the system:
 
@@ -11,3 +11,5 @@ Kiebitz systematically minimizes privacy & security risks for users of the syste
 * Individual system components can be federated and operated independently.
 * All components and protocols are open source and can be freely used and audited.
 * Possibilities for misuse of the system are largely excluded by technical and organisational measures.
+
+ [^1]: German for lapwing

--- a/src/site-all.yml.trans
+++ b/src/site-all.yml.trans
@@ -39,4 +39,4 @@ f624fcf0dcbb39c0:
   en: Data protection
 f864ff6066cf8348:
   de: Kiebitz Dokumentation
-  en: Lapwing Documentation
+  en: Kiebitz Documentation

--- a/src/translations/main.yml
+++ b/src/translations/main.yml
@@ -4,7 +4,7 @@ hp:
       de: 35999721736896d2
       en: 35999721736896d2
     de: Kiebitz! Dokumentation
-    en: Lapwing! Documentation
+    en: Kiebitz! Documentation
   translation-note:
     _t:
       de: 61cf1a0868a8f0f7


### PR DESCRIPTION
Although lapwing is the formally correct translation, it is not changed everywhere, and the repo name still is the repo name so I thought this should be consistent